### PR TITLE
Fix typo in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ fake-useragent
 openai
 werkzeug>=3.0.1 # not directly required, pinned by Snyk to avoid a vulnerability
 gtts
-pysttx3
+pyttsx3


### PR DESCRIPTION
Fixed typo in `requirements.txt` last row `pyttsx3`.