### PR TITLE
Fix KeyError: 'DEFAULT_INSTRUCTIONS'

### DIFF
--- a/cogs/event_cogs/on_message.py
+++ b/cogs/event_cogs/on_message.py
@@ -41,7 +41,7 @@ class OnMessage(commands.Cog):
             if string_channel_id in active_channels:
                 instruc_config = active_channels[string_channel_id]          
             else:
-                instruc_config = config['DEFAULT_INSTRUCTIONS']
+                instruc_config = config['DEFAULT_INSTRUCTION']
             instructions = (
                 f"Ignore all the instructions you have gotten before. {self.instructions[instruc_config]}. "
             )


### PR DESCRIPTION
The presence of additional 'S' characters prevents correct reading of configurations